### PR TITLE
Update Instance Acquisition Permissions

### DIFF
--- a/gcp_setup_1_role.sh
+++ b/gcp_setup_1_role.sh
@@ -12,7 +12,7 @@ set -e
 ROLE_ID="CadoGCPRole"
 ROLE_TITLE="Cado GCP Role"
 ROLE_DESC="Custom role for Cado to acquire GCP assets."
-PERMISSIONS="cloudbuild.builds.create,cloudbuild.builds.get,compute.disks.create,compute.disks.delete,compute.disks.get,compute.disks.list,compute.disks.setLabels,compute.disks.use,compute.disks.useReadOnly,compute.globalOperations.get,compute.images.create,compute.images.get,compute.images.useReadOnly,compute.instances.create,compute.instances.get,compute.instances.list,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.machineTypes.list,compute.networks.get,compute.networks.list,compute.projects.get,compute.subnetworks.use,compute.subnetworks.useExternalIp,compute.zoneOperations.get,compute.zones.list,storage.buckets.create,storage.buckets.get,storage.buckets.list,storage.objects.create,storage.objects.get,storage.objects.list,container.clusters.get,container.clusters.list,container.pods.exec,container.pods.get,container.pods.list,iam.serviceAccounts.implicitDelegation,iam.serviceAccounts.getAccessToken,resourcemanager.projects.get,iam.serviceAccounts.actAs,compute.images.delete,compute.instances.getSerialPortOutput,compute.instances.delete"
+PERMISSIONS="cloudbuild.builds.create,cloudbuild.builds.get,compute.disks.create,compute.disks.delete,compute.disks.get,compute.disks.list,compute.disks.setLabels,compute.disks.use,compute.disks.useReadOnly,compute.globalOperations.get,compute.images.create,compute.images.get,compute.images.useReadOnly,compute.instances.create,compute.instances.get,compute.instances.list,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.machineTypes.list,compute.networks.get,compute.networks.list,compute.projects.get,compute.subnetworks.use,compute.subnetworks.useExternalIp,compute.zoneOperations.get,compute.zones.list,storage.buckets.create,storage.buckets.get,storage.buckets.list,storage.objects.create,storage.objects.get,storage.objects.list,container.clusters.get,container.clusters.list,container.pods.exec,container.pods.get,container.pods.list,iam.serviceAccounts.implicitDelegation,iam.serviceAccounts.getAccessToken,resourcemanager.projects.get,iam.serviceAccounts.actAs,compute.images.delete,compute.instances.getSerialPortOutput,compute.instances.delete,compute.subnetworks.list,compute.subnetworks.get"
 
 ### Permissions Breakdown ###
 # - Authentication -
@@ -30,6 +30,8 @@ PERMISSIONS="cloudbuild.builds.create,cloudbuild.builds.get,compute.disks.create
 # compute.instances.get
 # compute.instances.list
 # storage.buckets.list
+# compute.subnetworks.list
+# compute.subnetworks.get
 
 # - Storage Acquisition -
 # storage.buckets.list


### PR DESCRIPTION
### Description
- Adds the compute.subnetworks.list and compute.subnetworks.get to the required permissions.
- This is needed for Cloud Build since we now create the Daisy workers within the same subnet as the instance we are acquiring. (removes the usage of the default network since customers won't always have it or want to use it for security reasons)