### PR TITLE
Update Cross Project Script

### DIFF
--- a/gcp_setup_4_cross_project.sh
+++ b/gcp_setup_4_cross_project.sh
@@ -22,10 +22,15 @@ PROJECT_NUMBER="$(gcloud projects describe "${PROJECT_ID}" --format='value(proje
 CADO_SERVICE_ACCOUNT_NAME="CadoServiceAccount"
 CADO_SERVICE_ACCOUNT_EMAIL="${CADO_SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 
-# Cloud Build used to use the legacy Cloud Build service account but as of 2024 moved to using the Compute Default service account
-# To support both, apply these permissions to both service accounts
+# Cloud Build used the legacy Cloud Build service account in the past (ending in @cloudbuild.gserviceaccount.com)
+# This has been changed to use the Compute service account instead as the default (ending in @developer.gserviceaccount.com). 
+# To support both, we apply these permissions to both service accounts.
+
+# More information about this change and these service accounts can be found here:
+# https://cloud.google.com/build/docs/cloud-build-service-account-updates
+# https://cloud.google.com/build/docs/cloud-build-service-account 
 CLOUD_BUILD_SERVICE_ACCOUNT_EMAIL="${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com"
-COMPUTE_SERVICE_ACCOUNT_EMAIL="${PROJECT_NUMBER}-compute@@developer.gserviceaccount.com"
+COMPUTE_SERVICE_ACCOUNT_EMAIL="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
 
 # Switch to target project and enable Cloud Build API
 gcloud config set project ${CROSS_PROJECT_ID}

--- a/gcp_setup_4_cross_project.sh
+++ b/gcp_setup_4_cross_project.sh
@@ -21,22 +21,28 @@ PROJECT_ID="$(gcloud config get-value project)"
 PROJECT_NUMBER="$(gcloud projects describe "${PROJECT_ID}" --format='value(projectNumber)')"
 CADO_SERVICE_ACCOUNT_NAME="CadoServiceAccount"
 CADO_SERVICE_ACCOUNT_EMAIL="${CADO_SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# Cloud Build used to use the legacy Cloud Build service account but as of 2024 moved to using the Compute Default service account
+# To support both, apply these permissions to both service accounts
 CLOUD_BUILD_SERVICE_ACCOUNT_EMAIL="${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com"
+COMPUTE_SERVICE_ACCOUNT_EMAIL="${PROJECT_NUMBER}-compute@@developer.gserviceaccount.com"
 
 # Switch to target project and enable Cloud Build API
 gcloud config set project ${CROSS_PROJECT_ID}
 gcloud services enable cloudbuild.googleapis.com --project "${PROJECT_ID}"
 
-# Add the origin project's CadoServiceAccount and CloudBuild service account to the target project's IAM
+# Add the origin project's CadoServiceAccount, Compute service account and CloudBuild service account to the target project's IAM
 gcloud projects add-iam-policy-binding "${CROSS_PROJECT_ID}" \
     --member "serviceAccount:${CADO_SERVICE_ACCOUNT_EMAIL}" \
     --role "${ROLE_ID}"
 gcloud projects add-iam-policy-binding "${CROSS_PROJECT_ID}" \
     --member "serviceAccount:${CLOUD_BUILD_SERVICE_ACCOUNT_EMAIL}" \
     --role "${ROLE_ID}"
+gcloud projects add-iam-policy-binding "${CROSS_PROJECT_ID}" \
+    --member "serviceAccount:${COMPUTE_SERVICE_ACCOUNT_EMAIL}" \
+    --role "${ROLE_ID}"
 
 # Switch back to origin project
 gcloud config set project ${PROJECT_ID}
 
-echo ""
 echo Successfully setup permissions. ${PROJECT_ID} can now acquire from ${CROSS_PROJECT_ID}


### PR DESCRIPTION
# Description
- Updated the script to also apply the permissions to the default compute service account as Cloud Build now uses this as the default service account instead of the default cloud build service account.
https://cloud.google.com/build/docs/cloud-build-service-account-updates